### PR TITLE
Make platform spawning more modular per level + Refactoring!

### DIFF
--- a/Assets/Scenes/LevelOneScene.unity
+++ b/Assets/Scenes/LevelOneScene.unity
@@ -9716,6 +9716,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
+      propertyPath: bpm
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
       propertyPath: noteTime
       value: 5
       objectReference: {fileID: 0}
@@ -9727,6 +9731,10 @@ PrefabInstance:
       propertyPath: audioSource
       value: 
       objectReference: {fileID: 1316515968}
+    - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
+      propertyPath: midiFileName
+      value: full_arrangement_v19.mid
+      objectReference: {fileID: 0}
     - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
       propertyPath: songLoopFast
       value: 
@@ -20606,7 +20614,7 @@ MonoBehaviour:
   TimeStamp: 0
   noteRestrictionRight: 1
   timeStampsRight: []
-  _inputIndexRight: 0
+  inputIndexRight: 0
 --- !u!1 &837080058
 GameObject:
   m_ObjectHideFlags: 0
@@ -44935,9 +44943,9 @@ MonoBehaviour:
   walkingSound: {fileID: 1370060877}
   sidewayWalkSpeed: 10.8
   forwardWalkSpeed: 8.8
-  sideMovementZOffset: 12
-  lane_positions: []
-  current_lane: 0
+  sideMovementZOffset: 4
+  lanePositions: []
+  currentLane: 0
   groundDrag: 4
   maxJumpForce: 18
   jumpCooldown: 0

--- a/Assets/Scenes/LevelOneScene.unity
+++ b/Assets/Scenes/LevelOneScene.unity
@@ -876,6 +876,7 @@ MonoBehaviour:
   platforms: []
   fishtreats: []
   laneNumber: 4
+  spacingSize: 2
 --- !u!4 &22304591
 Transform:
   m_ObjectHideFlags: 0
@@ -4054,6 +4055,7 @@ MonoBehaviour:
   platforms: []
   fishtreats: []
   laneNumber: 2
+  spacingSize: 2
 --- !u!4 &160308260
 Transform:
   m_ObjectHideFlags: 0
@@ -38390,6 +38392,7 @@ MonoBehaviour:
   platforms: []
   fishtreats: []
   laneNumber: 1
+  spacingSize: 2
 --- !u!4 &1563533518
 Transform:
   m_ObjectHideFlags: 0
@@ -39901,6 +39904,7 @@ MonoBehaviour:
   platforms: []
   fishtreats: []
   laneNumber: 3
+  spacingSize: 2
 --- !u!4 &1626550414
 Transform:
   m_ObjectHideFlags: 0
@@ -51183,6 +51187,7 @@ MonoBehaviour:
   platforms: []
   fishtreats: []
   laneNumber: 0
+  spacingSize: 2
 --- !u!4 &2122082842
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LevelOneScene.unity
+++ b/Assets/Scenes/LevelOneScene.unity
@@ -875,7 +875,6 @@ MonoBehaviour:
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
   fishtreats: []
-  spacingSize: 2
   laneNumber: 4
 --- !u!4 &22304591
 Transform:
@@ -4054,7 +4053,6 @@ MonoBehaviour:
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
   fishtreats: []
-  spacingSize: 2
   laneNumber: 2
 --- !u!4 &160308260
 Transform:
@@ -9731,6 +9729,10 @@ PrefabInstance:
       propertyPath: audioSource
       value: 
       objectReference: {fileID: 1316515968}
+    - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
+      propertyPath: spacingSize
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
       propertyPath: midiFileName
       value: full_arrangement_v19.mid
@@ -38387,7 +38389,6 @@ MonoBehaviour:
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
   fishtreats: []
-  spacingSize: 2
   laneNumber: 1
 --- !u!4 &1563533518
 Transform:
@@ -39899,7 +39900,6 @@ MonoBehaviour:
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
   fishtreats: []
-  spacingSize: 2
   laneNumber: 3
 --- !u!4 &1626550414
 Transform:
@@ -51182,7 +51182,6 @@ MonoBehaviour:
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
   fishtreats: []
-  spacingSize: 2
   laneNumber: 0
 --- !u!4 &2122082842
 Transform:

--- a/Assets/Scripts/ManagerScripts/GameManager.cs
+++ b/Assets/Scripts/ManagerScripts/GameManager.cs
@@ -4,7 +4,7 @@ using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
-    public static GameManager current;
+    public static GameManager Current;
 
     private static bool _gameIsPaused;
     public bool playerIsDying;
@@ -18,7 +18,7 @@ public class GameManager : MonoBehaviour
     private void Awake()
     {
         _playerMovement = playerGameObject.GetComponent<PlayerMovement>();
-        current = this;
+        Current = this;
         _gameHasEnded = false;
         _playerMovement.enabled = true;
         Cursor.lockState = CursorLockMode.Locked;
@@ -40,8 +40,8 @@ public class GameManager : MonoBehaviour
 
     public void LostLevel() {
         gameIsEnding = false;
-        PlayerMovement.current.walkingSound.Stop();
-        MusicPlayer.current.audioSource.Pause();
+        PlayerMovement.Current.walkingSound.Stop();
+        MusicPlayer.Current.audioSource.Pause();
         gameOverSound.Play();
         _playerMovement.enabled = false;
         UIManager.current.LostLevelUI();

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -12,13 +12,12 @@ public class Lane : MonoBehaviour
     public List<Platform> platforms = new List<Platform>();
     public List<FishHit> fishtreats = new List<FishHit>();
     
-    public float spacingSize = 2F; //based on the size of the current neutral platform
     public int laneNumber;
 
     private const float X = 0F;
     private float _y, _z;
 
-    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm)
+    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm, float spacingSize)
     {
         var oneEighthofBeat = (1 / (bpm / 60f)) / 2;
         foreach (var note in array)
@@ -33,18 +32,18 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == platformNote) {
                 /* Pre-spawning platforms before game starts */
-                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat);
+                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat, spacingSize);
             }
             if (note.NoteName == fishTreatNote)
             {
                 ScoreManager.current.maximumFishScore += 1;
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, spacingSize);
             }
         }
     }
 
     private void SpawnPlatform(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
-            float oneEighthofBeat)
+            float oneEighthofBeat, float spacingSize)
     //TODO: Check note velocity to spawn different types of platform
     {
         var newPlatform = Instantiate(platformPrefab, transform, true);
@@ -77,7 +76,8 @@ public class Lane : MonoBehaviour
         }
     }
 
-    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime)
+    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
+        float spacingSize)
     {
         // Debug.Log("spawned");
         var newFishtreat = Instantiate(fishTreatPrefab, transform, true);
@@ -94,7 +94,7 @@ public class Lane : MonoBehaviour
         fishtreats.Add(newFishtreat.GetComponent<FishHit>());
     }
 
-    public void RespawnAllFishTreats(IEnumerable<Note> array)
+    public void RespawnAllFishTreats(IEnumerable<Note> array, float spacingSize)
     {
         foreach (var note in array)
         {
@@ -104,7 +104,7 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == fishTreatNote)
             {
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, spacingSize);
             }
         }
     }

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -14,10 +14,15 @@ public class Lane : MonoBehaviour
     
     public float spacingSize = 2F; //based on the size of the current neutral platform
 
+    private float _oneEighthofBeat;
     public int laneNumber;
 
     private const float X = 0F;
     private float _y, _z;
+
+    private void Start() {
+        _oneEighthofBeat = (1 / (MusicPlayer.Current.bpm / 60f)) / 2;
+    }
 
     public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array)
     {
@@ -48,15 +53,17 @@ public class Lane : MonoBehaviour
     {
         var newPlatform = Instantiate(platformPrefab, transform, true);
         _y = (octave - 2) * 2F;
-        _z = (spawnTime / 0.25F) * spacingSize;
+        _z = (spawnTime / _oneEighthofBeat) * spacingSize;
         var position = new Vector3(X, _y, _z);
         newPlatform.transform.localPosition = position;
         newPlatform.transform.rotation = transform.rotation;
 
-        Color alteredColor = new Color();
-        alteredColor.r = newPlatform.GetComponent<Renderer>().material.color.r;
-        alteredColor.g = newPlatform.GetComponent<Renderer>().material.color.g;
-        alteredColor.b = newPlatform.GetComponent<Renderer>().material.color.b + (_y/50);
+        var alteredColor = new Color
+        {
+            r = newPlatform.GetComponent<Renderer>().material.color.r,
+            g = newPlatform.GetComponent<Renderer>().material.color.g,
+            b = newPlatform.GetComponent<Renderer>().material.color.b + (_y/50)
+        };
 
         newPlatform.GetComponent<Renderer>().material.color = alteredColor;
 
@@ -66,7 +73,7 @@ public class Lane : MonoBehaviour
             //Checkpoint
             var newCheckpoint = Instantiate(checkpointPrefab, transform, true);
             _y = (octave - 2) * 2F - 1.8F;
-            _z = (spawnTime / 0.25F) * spacingSize;
+            _z = (spawnTime / _oneEighthofBeat) * spacingSize;
             position = new Vector3(0.6F, _y, _z);
             newCheckpoint.transform.localPosition = position;
             newCheckpoint.transform.rotation = transform.rotation;

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -13,19 +13,14 @@ public class Lane : MonoBehaviour
     public List<FishHit> fishtreats = new List<FishHit>();
     
     public float spacingSize = 2F; //based on the size of the current neutral platform
-
-    private float _oneEighthofBeat;
     public int laneNumber;
 
     private const float X = 0F;
     private float _y, _z;
 
-    private void Start() {
-        _oneEighthofBeat = (1 / (MusicPlayer.Current.bpm / 60f)) / 2;
-    }
-
-    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array)
+    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm)
     {
+        var oneEighthofBeat = (1 / (bpm / 60f)) / 2;
         foreach (var note in array)
         {
             //Octave 1 is for player input
@@ -38,7 +33,7 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == platformNote) {
                 /* Pre-spawning platforms before game starts */
-                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime);
+                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat);
             }
             if (note.NoteName == fishTreatNote)
             {
@@ -48,12 +43,13 @@ public class Lane : MonoBehaviour
         }
     }
 
-    private void SpawnPlatform(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime)
+    private void SpawnPlatform(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
+            float oneEighthofBeat)
     //TODO: Check note velocity to spawn different types of platform
     {
         var newPlatform = Instantiate(platformPrefab, transform, true);
         _y = (octave - 2) * 2F;
-        _z = (spawnTime / _oneEighthofBeat) * spacingSize;
+        _z = (spawnTime / oneEighthofBeat) * spacingSize;
         var position = new Vector3(X, _y, _z);
         newPlatform.transform.localPosition = position;
         newPlatform.transform.rotation = transform.rotation;
@@ -73,7 +69,7 @@ public class Lane : MonoBehaviour
             //Checkpoint
             var newCheckpoint = Instantiate(checkpointPrefab, transform, true);
             _y = (octave - 2) * 2F - 1.8F;
-            _z = (spawnTime / _oneEighthofBeat) * spacingSize;
+            _z = (spawnTime / oneEighthofBeat) * spacingSize;
             position = new Vector3(0.6F, _y, _z);
             newCheckpoint.transform.localPosition = position;
             newCheckpoint.transform.rotation = transform.rotation;

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -13,11 +13,12 @@ public class Lane : MonoBehaviour
     public List<FishHit> fishtreats = new List<FishHit>();
     
     public int laneNumber;
-
+    public float spacingSize; //based on the size of the current neutral platform
+    
     private const float X = 0F;
     private float _y, _z;
 
-    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm, float spacingSize)
+    public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm)
     {
         var oneEighthofBeat = (1 / (bpm / 60f)) / 2;
         foreach (var note in array)
@@ -32,18 +33,18 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == platformNote) {
                 /* Pre-spawning platforms before game starts */
-                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat, spacingSize);
+                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat);
             }
             if (note.NoteName == fishTreatNote)
             {
                 ScoreManager.current.maximumFishScore += 1;
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, spacingSize);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
             }
         }
     }
 
     private void SpawnPlatform(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
-            float oneEighthofBeat, float spacingSize)
+            float oneEighthofBeat)
     //TODO: Check note velocity to spawn different types of platform
     {
         var newPlatform = Instantiate(platformPrefab, transform, true);
@@ -76,8 +77,7 @@ public class Lane : MonoBehaviour
         }
     }
 
-    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
-        float spacingSize)
+    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime)
     {
         // Debug.Log("spawned");
         var newFishtreat = Instantiate(fishTreatPrefab, transform, true);
@@ -94,7 +94,7 @@ public class Lane : MonoBehaviour
         fishtreats.Add(newFishtreat.GetComponent<FishHit>());
     }
 
-    public void RespawnAllFishTreats(IEnumerable<Note> array, float spacingSize)
+    public void RespawnAllFishTreats(IEnumerable<Note> array)
     {
         foreach (var note in array)
         {
@@ -104,7 +104,7 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == fishTreatNote)
             {
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, spacingSize);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
             }
         }
     }

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -13,6 +13,7 @@ public class Lane : MonoBehaviour
     public List<FishHit> fishtreats = new List<FishHit>();
     
     public int laneNumber;
+    private float _oneEighthofBeat;
     public float spacingSize; //based on the size of the current neutral platform
     
     private const float X = 0F;
@@ -20,7 +21,7 @@ public class Lane : MonoBehaviour
 
     public void SpawnPlatformsAndFishTreats(IEnumerable<Note> array, float bpm)
     {
-        var oneEighthofBeat = (1 / (bpm / 60f)) / 2;
+        _oneEighthofBeat = 1 / (bpm / 60f) / 2;
         foreach (var note in array)
         {
             //Octave 1 is for player input
@@ -33,12 +34,12 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == platformNote) {
                 /* Pre-spawning platforms before game starts */
-                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, oneEighthofBeat);
+                SpawnPlatform(note.Octave, note.Velocity, (float)spawnTime, _oneEighthofBeat);
             }
             if (note.NoteName == fishTreatNote)
             {
                 ScoreManager.current.maximumFishScore += 1;
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, _oneEighthofBeat);
             }
         }
     }
@@ -77,7 +78,8 @@ public class Lane : MonoBehaviour
         }
     }
 
-    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime)
+    private void SpawnFishTreat(int octave, Melanchall.DryWetMidi.Common.SevenBitNumber velocity, float spawnTime,
+        float oneEighthofBeat)
     {
         // Debug.Log("spawned");
         var newFishtreat = Instantiate(fishTreatPrefab, transform, true);
@@ -86,7 +88,7 @@ public class Lane : MonoBehaviour
         {
             _y += 2f;
         }
-        _z = (spawnTime / 0.25F) * spacingSize - 3.5f;
+        _z = (spawnTime / oneEighthofBeat) * spacingSize - 3.5f;
         var position = new Vector3(X, _y, _z);
         // Debug.Log(spawn_time);
         newFishtreat.transform.localPosition = position;
@@ -96,6 +98,7 @@ public class Lane : MonoBehaviour
 
     public void RespawnAllFishTreats(IEnumerable<Note> array)
     {
+        _oneEighthofBeat = 1 / (MusicPlayer.Current.bpm / 60f) / 2;
         foreach (var note in array)
         {
             var metricTimeSpan =
@@ -104,7 +107,7 @@ public class Lane : MonoBehaviour
                              (double)metricTimeSpan.Milliseconds / 1000f);
             if (note.NoteName == fishTreatNote)
             {
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime);
+                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, _oneEighthofBeat);
             }
         }
     }

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -43,7 +43,7 @@ public class MusicPlayer : MonoBehaviour
         // Debug.Log(notes.Count);
         notes.CopyTo(array, 0);
         foreach (var lane in lanes){
-            lane.SpawnPlatformsAndFishTreats(array);
+            lane.SpawnPlatformsAndFishTreats(array, bpm);
             // Debug.Log(lane.timeStamps.Count);
         }
         foreach (var playerAction in playerActions){

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -17,7 +17,6 @@ public class MusicPlayer : MonoBehaviour
 
     public static MidiFile MidiFileTest;
     public float bpm;
-    public float spacingSize; //based on the size of the current neutral platform
 
     public string midiFileName;
     public Lane[] lanes;
@@ -44,7 +43,7 @@ public class MusicPlayer : MonoBehaviour
         // Debug.Log(notes.Count);
         notes.CopyTo(array, 0);
         foreach (var lane in lanes){
-            lane.SpawnPlatformsAndFishTreats(array, bpm, spacingSize);
+            lane.SpawnPlatformsAndFishTreats(array, bpm);
             // Debug.Log(lane.timeStamps.Count);
         }
         foreach (var playerAction in playerActions){
@@ -103,7 +102,7 @@ public class MusicPlayer : MonoBehaviour
         notes.CopyTo(array, 0);
         foreach (var lane in lanes){
             lane.DestroyAllFishTreats();
-            lane.RespawnAllFishTreats(array, spacingSize);
+            lane.RespawnAllFishTreats(array);
         }
     }
 }

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -49,6 +49,7 @@ public class MusicPlayer : MonoBehaviour
         foreach (var playerAction in playerActions){
             playerAction.SetTimeStamps(array);
         }
+        BeatHop.Current.SetFrequency(bpm);
 
         audioSource.clip = songIntroNormal;
         audioSource.loop = false;

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -4,7 +4,7 @@ using Melanchall.DryWetMidi.Interaction;
 
 public class MusicPlayer : MonoBehaviour
 {
-    public static MusicPlayer current;
+    public static MusicPlayer Current;
     
     public AudioSource audioSource;
     public AudioClip songIntroNormal;
@@ -16,8 +16,9 @@ public class MusicPlayer : MonoBehaviour
     // public float dspSongTime;
 
     public static MidiFile MidiFileTest;
-    public float noteTime;
+    public float bpm;
 
+    public string midiFileName;
     public Lane[] lanes;
     public PlayerAction[] playerActions;
     public double marginOfError = 0.3;
@@ -26,16 +27,16 @@ public class MusicPlayer : MonoBehaviour
     private bool _audioPlayed;
     private void Awake()
     {
-        current = this;
+        Current = this;
     }
     
     private void Start()
     {
         MidiFileTest = null;
         if (Application.platform is RuntimePlatform.WindowsPlayer or RuntimePlatform.OSXEditor or RuntimePlatform.WindowsEditor)
-            MidiFileTest = MidiFile.Read(Application.dataPath + "/StreamingAssets/full_arrangement_v19.mid");
+            MidiFileTest = MidiFile.Read(Application.dataPath + "/StreamingAssets/" + midiFileName);
         if (Application.platform == RuntimePlatform.OSXPlayer)
-            MidiFileTest = MidiFile.Read(Application.dataPath + "/Resources/Data/StreamingAssets/full_arrangement_v19.mid");
+            MidiFileTest = MidiFile.Read(Application.dataPath + "/Resources/Data/StreamingAssets/" + midiFileName);
         
         var notes = MidiFileTest.GetNotes();
         var array = new Note[notes.Count];
@@ -90,7 +91,7 @@ public class MusicPlayer : MonoBehaviour
 
     public double GetAudioSourceTime()
     {
-        return (double)current.audioSource.timeSamples / current.audioSource.clip.frequency;
+        return (double)Current.audioSource.timeSamples / Current.audioSource.clip.frequency;
     }
 
     public void ResetAllFishTreats()

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -17,6 +17,7 @@ public class MusicPlayer : MonoBehaviour
 
     public static MidiFile MidiFileTest;
     public float bpm;
+    public float spacingSize; //based on the size of the current neutral platform
 
     public string midiFileName;
     public Lane[] lanes;
@@ -43,7 +44,7 @@ public class MusicPlayer : MonoBehaviour
         // Debug.Log(notes.Count);
         notes.CopyTo(array, 0);
         foreach (var lane in lanes){
-            lane.SpawnPlatformsAndFishTreats(array, bpm);
+            lane.SpawnPlatformsAndFishTreats(array, bpm, spacingSize);
             // Debug.Log(lane.timeStamps.Count);
         }
         foreach (var playerAction in playerActions){
@@ -102,7 +103,7 @@ public class MusicPlayer : MonoBehaviour
         notes.CopyTo(array, 0);
         foreach (var lane in lanes){
             lane.DestroyAllFishTreats();
-            lane.RespawnAllFishTreats(array);
+            lane.RespawnAllFishTreats(array, spacingSize);
         }
     }
 }

--- a/Assets/Scripts/ManagerScripts/RespawnManager.cs
+++ b/Assets/Scripts/ManagerScripts/RespawnManager.cs
@@ -5,17 +5,16 @@ using UnityEngine;
 
 public class RespawnManager : MonoBehaviour
 {
-    public static RespawnManager current;
+    public static RespawnManager Current;
 
     private void Awake()
     {
-        current = this;
+        Current = this;
     }
 
     private Vector3 _respawnPointLocation;
     public int respawnLane;
     private float _musicTime;
-    private ITimeSpan _midiTime;
 
     [SerializeField] public GameObject playerCharacter;
     private Rigidbody _playerCharacterRb;
@@ -35,7 +34,6 @@ public class RespawnManager : MonoBehaviour
         respawnLane = 2;
         _playerCharacterRb = playerCharacter.GetComponent<Rigidbody>();
         _playerCharacterMovement = playerCharacter.GetComponent<PlayerMovement>();
-        _midiTime = new MetricTimeSpan(0);
         _playerFishScore = scoreManager.GetPlayerFishScore();
         _playerAccuracyScore = scoreManager.GetPlayerAccuracyScore();
         _inputIndexSBA = SingleButtonAction.Current.GetInputIndex();
@@ -45,10 +43,10 @@ public class RespawnManager : MonoBehaviour
 
     public IEnumerator RespawnPlayer(float respawnClipLength)
     {
-        GameManager.current.playerIsDying = true;
+        GameManager.Current.playerIsDying = true;
 
         // Reset Fish Treats on the lanes
-        MusicPlayer.current.ResetAllFishTreats();
+        MusicPlayer.Current.ResetAllFishTreats();
         
         // Reset values
         AdjustMusicTime();
@@ -62,16 +60,16 @@ public class RespawnManager : MonoBehaviour
         PlayerSideAction.Current.SetInputIndexRight(_inputIndexRightPSA);
 
         // Reset music related values
-        MusicPlayer.current.Resume();
+        MusicPlayer.Current.Resume();
         //MidiManager.current.ResumePlayback();
-        GameManager.current.playerIsDying = false;
+        GameManager.Current.playerIsDying = false;
         yield return null;
     }
 
     private void AdjustMusicTime()
     {
-        MusicPlayer.current.Pause();
-        MusicPlayer.current.audioSource.time = _musicTime;
+        MusicPlayer.Current.Pause();
+        MusicPlayer.Current.audioSource.time = _musicTime;
     }
 
     private void AdjustPlayerPosition()
@@ -79,7 +77,7 @@ public class RespawnManager : MonoBehaviour
         playerCharacter.transform.position = _respawnPointLocation;
         playerCharacter.transform.rotation = new Quaternion(0,0,0,0);
         _playerCharacterRb.velocity = new Vector3(0,0,1f);
-        _playerCharacterMovement.current_lane = respawnLane;
+        _playerCharacterMovement.currentLane = respawnLane;
     }
 
     // private void AdjustMidiTime()
@@ -100,7 +98,6 @@ public class RespawnManager : MonoBehaviour
 
     public void SetMidiTime(ITimeSpan midiTime)
     {
-        _midiTime = midiTime;
     }
 
     public void SetPlayerFishScore(int score)

--- a/Assets/Scripts/ObjectScripts/BeatHop.cs
+++ b/Assets/Scripts/ObjectScripts/BeatHop.cs
@@ -10,7 +10,7 @@ public class BeatHop : MonoBehaviour
         Current = this;
     }
 
-    private const float Amplitude = 0.4f;
+    private const float Amplitude = -0.4f;
     private Vector3 _initialPosition;
     private float _frequency = 1f;
 
@@ -29,7 +29,7 @@ public class BeatHop : MonoBehaviour
         if (Time.timeSinceLevelLoad > 5f)
         {
             transform.position = new Vector3(_initialPosition.x,
-                Mathf.Sin(Time.time * _frequency * 2*Mathf.PI) * Amplitude + _initialPosition.y,
+                Mathf.Cos(Time.time * _frequency * 2*Mathf.PI) * Amplitude + _initialPosition.y,
                 _initialPosition.z);
         }
     }

--- a/Assets/Scripts/ObjectScripts/BeatHop.cs
+++ b/Assets/Scripts/ObjectScripts/BeatHop.cs
@@ -3,13 +3,25 @@ using UnityEngine;
 
 public class BeatHop : MonoBehaviour
 {
+    public static BeatHop Current;
+
+    private void Awake()
+    {
+        Current = this;
+    }
+
     private const float Amplitude = 0.4f;
     private Vector3 _initialPosition;
-    private const float Frequency = 1f;
+    private float _frequency = 1f;
 
     private void Start()
     {
         _initialPosition = transform.position;
+    }
+
+    public void SetFrequency(float bpm)
+    {
+        _frequency = bpm / 120;
     }
 
     private void Update()
@@ -17,7 +29,7 @@ public class BeatHop : MonoBehaviour
         if (Time.timeSinceLevelLoad > 5f)
         {
             transform.position = new Vector3(_initialPosition.x,
-                Mathf.Sin(Time.time * Frequency * 2*Mathf.PI) * Amplitude + _initialPosition.y,
+                Mathf.Sin(Time.time * _frequency * 2*Mathf.PI) * Amplitude + _initialPosition.y,
                 _initialPosition.z);
         }
     }

--- a/Assets/Scripts/ObjectScripts/CameraMovement.cs
+++ b/Assets/Scripts/ObjectScripts/CameraMovement.cs
@@ -1,24 +1,20 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using Cinemachine;
 
 [RequireComponent(typeof(CinemachineVirtualCamera))]
 public class CameraMovement : MonoBehaviour
 {
-    private CinemachineVirtualCamera cinemachineVirtualCamera;
+    private CinemachineVirtualCamera _cinemachineVirtualCamera;
     public GameObject playerGameObject;
-    private float speed = 2.5f;
-    private Vector3 lookAtPoint;
+    private const float Speed = 2.5f;
     private bool _playCameraRotateAnimation;
 
     // Start is called before the first frame update
-    void Awake()
+    private void Awake()
     {
-        cinemachineVirtualCamera = GetComponent<CinemachineVirtualCamera>();
-        cinemachineVirtualCamera.m_Follow = playerGameObject.transform;
+        _cinemachineVirtualCamera = GetComponent<CinemachineVirtualCamera>();
+        _cinemachineVirtualCamera.m_Follow = playerGameObject.transform;
 
-        lookAtPoint = playerGameObject.transform.position;
         _playCameraRotateAnimation = false;
     }
 
@@ -26,18 +22,18 @@ public class CameraMovement : MonoBehaviour
     void Update()
     {
         if (_playCameraRotateAnimation) {
-            cinemachineVirtualCamera.m_Follow = null;
-            cinemachineVirtualCamera.m_LookAt = playerGameObject.transform;
-            float rotationAroundYAxis = -10 * Time.deltaTime * speed; // camera moves horizontally
-            float rotationAroundXAxis = -5 * Time.deltaTime * speed; // camera moves vertically
+            _cinemachineVirtualCamera.m_Follow = null;
+            _cinemachineVirtualCamera.m_LookAt = playerGameObject.transform;
+            float rotationAroundYAxis = -10 * Time.deltaTime * Speed; // camera moves horizontally
+            float rotationAroundXAxis = -5 * Time.deltaTime * Speed; // camera moves vertically
             
             transform.Rotate(new Vector3(1, 0, 0), rotationAroundXAxis);
             transform.Rotate(new Vector3(0, 1, 0), rotationAroundYAxis, Space.World);
             
-            transform.Translate(new Vector3(1, -1, 2) * Time.deltaTime * speed, Space.World);
+            transform.Translate(new Vector3(1, -1, 2) * (Time.deltaTime * Speed), Space.World);
         } else {
-            cinemachineVirtualCamera.m_Follow = playerGameObject.transform;
-            cinemachineVirtualCamera.m_LookAt = null;
+            _cinemachineVirtualCamera.m_Follow = playerGameObject.transform;
+            _cinemachineVirtualCamera.m_LookAt = null;
         }
     }
 

--- a/Assets/Scripts/ObjectScripts/Checkpoint.cs
+++ b/Assets/Scripts/ObjectScripts/Checkpoint.cs
@@ -49,21 +49,21 @@ public class Checkpoint : MonoBehaviour
         //animator.Play("CatCheckpointCycle", 0, 0f);
         Destroy(gameObject);
         //RespawnManager.current.SetMidiTime(MidiManager.current.GetPlaybackTime());
-        RespawnManager.current.SetMusicTime(MusicPlayer.current.audioSource.time);
+        RespawnManager.Current.SetMusicTime(MusicPlayer.Current.audioSource.time);
 
         playerFishScore = scoreManager.GetPlayerFishScore();
-        RespawnManager.current.SetPlayerFishScore(playerFishScore);
+        RespawnManager.Current.SetPlayerFishScore(playerFishScore);
         playerAccuracyScore = scoreManager.GetPlayerAccuracyScore();
-        RespawnManager.current.SetPlayerAccuracyScore(playerAccuracyScore);
+        RespawnManager.Current.SetPlayerAccuracyScore(playerAccuracyScore);
 
         inputIndexSBA = SingleButtonAction.Current.GetInputIndex();
-        RespawnManager.current.SetInputIndexSBA(inputIndexSBA);
+        RespawnManager.Current.SetInputIndexSBA(inputIndexSBA);
         inputIndexPSA = SingleButtonAction.Current.GetInputIndex();
-        RespawnManager.current.SetInputIndexPSA(inputIndexPSA);
+        RespawnManager.Current.SetInputIndexPSA(inputIndexPSA);
         inputIndexRightPSA = SingleButtonAction.Current.GetInputIndex();
-        RespawnManager.current.SetInputIndexRightPSA(inputIndexRightPSA);
+        RespawnManager.Current.SetInputIndexRightPSA(inputIndexRightPSA);
 
-        RespawnManager.current.SetRespawnPoint(
+        RespawnManager.Current.SetRespawnPoint(
             PlayerSyncPosition.Current.GetPlayerPosMusicTimeSyncedPosition(transform.position.y + _catRspawnOffsetY),
             laneNumber);
         checkpointSound.Play();

--- a/Assets/Scripts/ObjectScripts/EndWall.cs
+++ b/Assets/Scripts/ObjectScripts/EndWall.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class EndWall : MonoBehaviour
@@ -8,7 +6,7 @@ public class EndWall : MonoBehaviour
     {
         if (otherCollider.gameObject.CompareTag("Player"))
         {
-            GameManager.current.gameIsEnding = true;
+            GameManager.Current.gameIsEnding = true;
         }
     }
 }

--- a/Assets/Scripts/ObjectScripts/Platform.cs
+++ b/Assets/Scripts/ObjectScripts/Platform.cs
@@ -18,7 +18,7 @@ public abstract class Platform : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (other.CompareTag("Player") && !GameManager.current.playerIsDying && Time.time > 1)
+        if (other.CompareTag("Player") && !GameManager.Current.playerIsDying && Time.time > 1)
             PlayerSyncPosition.Current.SyncPlayerPosToMusicTime(transform.position.y  + 1f);
     }
 }

--- a/Assets/Scripts/ObjectScripts/PlayerHop.cs
+++ b/Assets/Scripts/ObjectScripts/PlayerHop.cs
@@ -23,7 +23,7 @@ public class PlayerHop : MonoBehaviour
             _rb.velocity = new Vector3(0, 0, 0);
             _hopping = false;
         }
-        if (Math.Abs(MusicPlayer.current.GetAudioSourceTime() - SingleButtonAction.Current.GetNextTimestamp(_hopIndex)) < 0.1f)
+        if (Math.Abs(MusicPlayer.Current.GetAudioSourceTime() - SingleButtonAction.Current.GetNextTimestamp(_hopIndex)) < 0.1f)
         {
             Hop();
         }
@@ -31,7 +31,7 @@ public class PlayerHop : MonoBehaviour
 
     private void FixedUpdate()
     {
-        _rb.AddForce(Vector3.down * ((PlayerMovement.current.jumpingGravity + 5.5f) * _rb.mass));
+        _rb.AddForce(Vector3.down * ((PlayerMovement.Current.jumpingGravity + 5.5f) * _rb.mass));
 
     }
 
@@ -40,7 +40,7 @@ public class PlayerHop : MonoBehaviour
         if (_hopping == false)
         {
             _hopping = true;
-            _rb.AddForce(transform.up * PlayerMovement.current.maxJumpForce, ForceMode.Impulse);
+            _rb.AddForce(transform.up * PlayerMovement.Current.maxJumpForce, ForceMode.Impulse);
             _hopIndex++;
         }
     }

--- a/Assets/Scripts/ObjectScripts/Respawner.cs
+++ b/Assets/Scripts/ObjectScripts/Respawner.cs
@@ -14,7 +14,7 @@ public class Respawner : MonoBehaviour
 
     private void OnTriggerEnter(Collider otherCollider) 
     {
-        if (otherCollider.gameObject.CompareTag("Player") && !GameManager.current.playerIsDying)
+        if (otherCollider.gameObject.CompareTag("Player") && !GameManager.Current.playerIsDying)
         {
             LifeManager.current.LostLife();
             if (LifeManager.current.playerLives != 0)

--- a/Assets/Scripts/PlayerScripts/PlayerAction.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerAction.cs
@@ -11,8 +11,8 @@ public abstract class PlayerAction : MonoBehaviour
     public List<double> timeStamps = new List<double>();
     public double blinkOffset;
     public double blinkCooldown;
-    protected double _previousBlink;
-    protected bool _ableToBlink;
+    protected double PreviousBlink;
+    protected bool AbleToBlink;
     protected int InputIndex;
     public int prespawnWarningSeconds;
     public double TimeStamp;
@@ -20,8 +20,8 @@ public abstract class PlayerAction : MonoBehaviour
     protected double AudioTime;
 
     private void Start() {
-        MarginOfError = MusicPlayer.current.marginOfError;
-        _ableToBlink = true;
+        MarginOfError = MusicPlayer.Current.marginOfError;
+        AbleToBlink = true;
     }
 
     public abstract void SetTimeStamps(IEnumerable<Note> array);
@@ -32,15 +32,10 @@ public abstract class PlayerAction : MonoBehaviour
     protected (bool ableToBlink, double previousBlink) CheckBlink(Color blinkColor, Color otherBlinkColor, double timeStamp, double otherTimeStamp, bool ableToBlink, double previousBlink){
         if(!ableToBlink && AudioTime > previousBlink + blinkCooldown){
                 ableToBlink = true;
-            }
+        }
 
         if (timeStamp - blinkOffset <= AudioTime && timeStamp > AudioTime){
-            if (otherTimeStamp == timeStamp){
-                Blink(otherBlinkColor);
-            }
-            else{
-                Blink(blinkColor);
-            }
+            Blink(otherTimeStamp == timeStamp ? otherBlinkColor : blinkColor);
             ableToBlink = false;
             previousBlink = AudioTime;
         }

--- a/Assets/Scripts/PlayerScripts/PlayerSideAction.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerSideAction.cs
@@ -9,12 +9,12 @@ public class PlayerSideAction : PlayerAction
 
     public Melanchall.DryWetMidi.MusicTheory.NoteName noteRestrictionRight;
     public List<double> timeStampsRight = new List<double>();
-    public int _inputIndexRight;
+    public int inputIndexRight;
     private double _timeStampRight;
-    protected double _previousBlinkRight;
-    protected bool _ableToBlinkRight;
-    private Color blinkColorLeft;
-    private Color blinkColorRight;
+    private double _previousBlinkRight;
+    private bool _ableToBlinkRight;
+    private Color _blinkColorLeft;
+    private Color _blinkColorRight;
 
     private void Awake()
     {
@@ -22,8 +22,8 @@ public class PlayerSideAction : PlayerAction
     }
 
     private void Start() {
-        blinkColorLeft = new Color(1f, 0.83f, 0f); //Yellow
-        blinkColorRight = new Color(0.47f, 0.31f, 0.66f); //Purple
+        _blinkColorLeft = new Color(1f, 0.83f, 0f); //Yellow
+        _blinkColorRight = new Color(0.47f, 0.31f, 0.66f); //Purple
     }
 
     public int GetInputIndex()
@@ -38,12 +38,12 @@ public class PlayerSideAction : PlayerAction
 
     public int GetInputIndexRight()
     {
-        return _inputIndexRight;
+        return inputIndexRight;
     }
 
     public void SetInputIndexRight(int inputIR)
     {
-        _inputIndexRight = inputIR;
+        inputIndexRight = inputIR;
     }
 
     public override void SetTimeStamps(IEnumerable<Note> array)
@@ -58,21 +58,21 @@ public class PlayerSideAction : PlayerAction
     // Update is called once per frame
     public override void Update()
     {
-        if (Time.timeSinceLevelLoad > 5 && !GameManager.current.IsGamePaused())
+        if (Time.timeSinceLevelLoad > 5 && !GameManager.Current.IsGamePaused())
         {
-            MarginOfError = MusicPlayer.current.marginOfError;
-            AudioTime = MusicPlayer.current.GetAudioSourceTime() - (MusicPlayer.current.inputDelayInMilliseconds / 1000.0);
+            MarginOfError = MusicPlayer.Current.marginOfError;
+            AudioTime = MusicPlayer.Current.GetAudioSourceTime() - (MusicPlayer.Current.inputDelayInMilliseconds / 1000.0);
 
-            (_ableToBlink, _previousBlink) = CheckBlink(blinkColorLeft, SingleButtonAction.Current.blinkColor, TimeStamp, SingleButtonAction.Current.TimeStamp, _ableToBlink, _previousBlink);
-            (_ableToBlinkRight, _previousBlinkRight) = CheckBlink(blinkColorRight, SingleButtonAction.Current.blinkColor, _timeStampRight, SingleButtonAction.Current.TimeStamp,_ableToBlinkRight, _previousBlinkRight);
+            (AbleToBlink, PreviousBlink) = CheckBlink(_blinkColorLeft, SingleButtonAction.Current.blinkColor, TimeStamp, SingleButtonAction.Current.TimeStamp, AbleToBlink, PreviousBlink);
+            (_ableToBlinkRight, _previousBlinkRight) = CheckBlink(_blinkColorRight, SingleButtonAction.Current.blinkColor, _timeStampRight, SingleButtonAction.Current.TimeStamp,_ableToBlinkRight, _previousBlinkRight);
             
             if (InputIndex < timeStamps.Count){
                 TimeStamp = timeStamps[InputIndex];
                 InputIndex = CheckMiss(InputIndex, TimeStamp);
             }
-            if (_inputIndexRight < timeStampsRight.Count){
-                _timeStampRight = timeStampsRight[_inputIndexRight];
-                _inputIndexRight = CheckMiss(_inputIndexRight, _timeStampRight);
+            if (inputIndexRight < timeStampsRight.Count){
+                _timeStampRight = timeStampsRight[inputIndexRight];
+                inputIndexRight = CheckMiss(inputIndexRight, _timeStampRight);
             }
         }
     }
@@ -82,18 +82,18 @@ public class PlayerSideAction : PlayerAction
         if (left){
             InputIndex = GetAccuracy( TimeStamp, InputIndex);
         }else{
-            _inputIndexRight = GetAccuracy( _timeStampRight, _inputIndexRight);
+            inputIndexRight = GetAccuracy( _timeStampRight, inputIndexRight);
         }
     }
     
     public override void TriggerScoreCalculation(InputAction.CallbackContext context)
     {
-        if (Time.timeSinceLevelLoad > 5 && !GameManager.current.IsGamePaused())
+        if (Time.timeSinceLevelLoad > 5 && !GameManager.Current.IsGamePaused())
         {
             if (context.performed && context.ReadValue<Vector2>().x == -1 && InputIndex < timeStamps.Count){
                 GetAccuracySide(true);
             }
-            else if (context.performed && context.ReadValue<Vector2>().x == 1 && _inputIndexRight < timeStampsRight.Count){
+            else if (context.performed && context.ReadValue<Vector2>().x == 1 && inputIndexRight < timeStampsRight.Count){
                 GetAccuracySide(false);
             }
         }

--- a/Assets/Scripts/PlayerScripts/PlayerSyncPosition.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerSyncPosition.cs
@@ -21,9 +21,9 @@ public class PlayerSyncPosition : MonoBehaviour
     {
         return new Vector3
         {
-            x = PlayerMovement.current.lane_positions[PlayerMovement.current.current_lane],
+            x = PlayerMovement.Current.lanePositions[PlayerMovement.Current.currentLane],
             y = yValue,
-            z = (float) (8 * MusicPlayer.current.GetAudioSourceTime() + _initPos.z)
+            z = (float) (8 * MusicPlayer.Current.GetAudioSourceTime() + _initPos.z)
         };
     }
 

--- a/Assets/Scripts/PlayerScripts/PlayerSyncPosition.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerSyncPosition.cs
@@ -23,7 +23,7 @@ public class PlayerSyncPosition : MonoBehaviour
         {
             x = PlayerMovement.Current.lanePositions[PlayerMovement.Current.currentLane],
             y = yValue,
-            z = (float) (8 * MusicPlayer.Current.GetAudioSourceTime() + _initPos.z)
+            z = (float) ((PlayerMovement.Current.forwardWalkSpeed - 0.8f) * MusicPlayer.Current.GetAudioSourceTime() + _initPos.z)
         };
     }
 

--- a/Assets/Scripts/PlayerScripts/SingleButtonAction.cs
+++ b/Assets/Scripts/PlayerScripts/SingleButtonAction.cs
@@ -38,20 +38,20 @@ public class SingleButtonAction : PlayerAction
     // Update is called once per frame
     public override void Update()
     {   
-        if (Time.timeSinceLevelLoad > 5 && !GameManager.current.IsGamePaused() && InputIndex < timeStamps.Count)
+        if (Time.timeSinceLevelLoad > 5 && !GameManager.Current.IsGamePaused() && InputIndex < timeStamps.Count)
         {
-            MarginOfError = MusicPlayer.current.marginOfError;
-            AudioTime = MusicPlayer.current.GetAudioSourceTime() - (MusicPlayer.current.inputDelayInMilliseconds / 1000.0);
+            MarginOfError = MusicPlayer.Current.marginOfError;
+            AudioTime = MusicPlayer.Current.GetAudioSourceTime() - (MusicPlayer.Current.inputDelayInMilliseconds / 1000.0);
             TimeStamp = timeStamps[InputIndex];
 
-            (_ableToBlink, _previousBlink) = CheckBlink(blinkColor, blinkColor, TimeStamp, TimeStamp,  _ableToBlink, _previousBlink);
+            (AbleToBlink, PreviousBlink) = CheckBlink(blinkColor, blinkColor, TimeStamp, TimeStamp,  AbleToBlink, PreviousBlink);
             
             InputIndex = CheckMiss(InputIndex, TimeStamp);
         }
     }
     public override void TriggerScoreCalculation(InputAction.CallbackContext context)
     {
-        if (context.performed && Time.timeSinceLevelLoad > 5 && !GameManager.current.IsGamePaused() && InputIndex < timeStamps.Count)
+        if (context.performed && Time.timeSinceLevelLoad > 5 && !GameManager.Current.IsGamePaused() && InputIndex < timeStamps.Count)
         {
             InputIndex = GetAccuracy(TimeStamp, InputIndex);
         }

--- a/Assets/Scripts/UIScripts/PauseScreen.cs
+++ b/Assets/Scripts/UIScripts/PauseScreen.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.SceneManagement;
 
 public class PauseScreen : MonoBehaviour
 {
@@ -17,16 +16,16 @@ public class PauseScreen : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetAxis("Mouse X") != 0 && GameManager.current.IsGamePaused())
+        if (Input.GetAxis("Mouse X") != 0 && GameManager.Current.IsGamePaused())
         {
             Cursor.visible = true;
         }
-        if (Input.GetKeyDown(KeyCode.Escape) && !GameManager.current.HasGameEnded())
+        if (Input.GetKeyDown(KeyCode.Escape) && !GameManager.Current.HasGameEnded())
         {
-            if (GameManager.current.IsGamePaused() && !settingsMenuUI.activeInHierarchy)
+            if (GameManager.Current.IsGamePaused() && !settingsMenuUI.activeInHierarchy)
             {
                 Resume();
-            } else if (GameManager.current.IsGamePaused() && settingsMenuUI.activeInHierarchy)
+            } else if (GameManager.Current.IsGamePaused() && settingsMenuUI.activeInHierarchy)
             {
                 SettingsMenu.current.BackToMainMenuOrPauseScreen();
                 settingsMenuUI.SetActive(false);
@@ -50,7 +49,7 @@ public class PauseScreen : MonoBehaviour
         }
         Invoke(nameof(EnableMovement), 0.3f);
         Time.timeScale = 1f;
-        GameManager.current.ResumeGame();
+        GameManager.Current.ResumeGame();
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
     }
@@ -63,9 +62,9 @@ public class PauseScreen : MonoBehaviour
         musicPlayer.Pause();
         //MidiManager.current.PausePlayback();
         _playerMovementScript.enabled = false;
-        PlayerMovement.current.walkingSound.Stop();
+        PlayerMovement.Current.walkingSound.Stop();
         Time.timeScale = 0f;
-        GameManager.current.PauseGame();
+        GameManager.Current.PauseGame();
         // This is because the camera script locks the cursor,
         // so we need to enable it again to be able to click buttons
         Cursor.lockState = CursorLockMode.None;
@@ -76,17 +75,17 @@ public class PauseScreen : MonoBehaviour
         Time.timeScale = 1f;
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
-        GameManager.current.RestartLevel();
+        GameManager.Current.RestartLevel();
     }
     public void MainMenu()
     {
         Time.timeScale = 1f;
-        GameManager.current.BackToMainMenu();
+        GameManager.Current.BackToMainMenu();
     }
     public void PauseOrResumeController()
     {
-        if (GameManager.current.HasGameEnded()) return;
-        if (GameManager.current.IsGamePaused())
+        if (GameManager.Current.HasGameEnded()) return;
+        if (GameManager.Current.IsGamePaused())
         {
             Resume();
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -137,7 +137,6 @@ PlayerSettings:
   bundleVersion: 1.3
   preloadedAssets:
   - {fileID: 0}
-  - {fileID: 11400000, guid: d3b6dfd46c2c943c2b7936b1ded4ebd2, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -137,6 +137,7 @@ PlayerSettings:
   bundleVersion: 1.3
   preloadedAssets:
   - {fileID: 0}
+  - {fileID: 11400000, guid: d3b6dfd46c2c943c2b7936b1ded4ebd2, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
- Added public attributes "BPM" and "midiFileName" to MusicPlayer.cs and "spacingSize" to Lane.cs that could be set in the inspector window based on the level properties. These attributes will adjust the spawn time of platforms.
- PlayerSyncPosition is now dependent on player's walkForwardSpeed
- Refactored nearly all scripts: Use consistent naming, remove unused imports and unused variables, and minor performance improvements

Note: Platform spawning needs to manually be set by:
1. Setting BPM in MusicPlayer.cs
2. Setting file name of midi in midiFileName in MusicPlayer.cs
3. Possibly adjusting spacingSize for all lanes in the scene
4. Possibly creating modified version of RectanglePlatform prefab and setting it for all lanes in the scene
Note 2: Player movement speed should be manually set (Maybe could be calculated using BPM?)
