### PR TITLE
Improve FishTreat destroy/respawn performance

### DIFF
--- a/Assets/Scenes/LevelOneScene.unity
+++ b/Assets/Scenes/LevelOneScene.unity
@@ -934,7 +934,6 @@ MonoBehaviour:
   fishTreatPrefab: {fileID: 246226352112295802, guid: d48770eaeb2450041975b4b13379f0bd, type: 3}
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
-  fishtreats: []
   laneNumber: 4
   spacingSize: 2
 --- !u!4 &22304591
@@ -4302,7 +4301,6 @@ MonoBehaviour:
   fishTreatPrefab: {fileID: 246226352112295802, guid: d48770eaeb2450041975b4b13379f0bd, type: 3}
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
-  fishtreats: []
   laneNumber: 2
   spacingSize: 2
 --- !u!4 &160308260
@@ -6211,8 +6209,8 @@ MonoBehaviour:
   countdownText: {fileID: 1533188171}
   countdownUI: {fileID: 363486406}
   countdownSound: {fileID: 573348226}
-  playerGameObject: {fileID: 1828724611}
   shouldCountTime: 0
+  playerGameObject: {fileID: 1828724611}
 --- !u!1 &218272260
 GameObject:
   m_ObjectHideFlags: 0
@@ -14157,6 +14155,50 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 375d8d89f94b439b85be3ef7cf4ab6c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &525958788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 525958789}
+  - component: {fileID: 525958790}
+  m_Layer: 0
+  m_Name: FishTreatManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &525958789
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 525958788}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 761166639}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &525958790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 525958788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03606caf957a41b5af08bae2fe47e30f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &528123430
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19819,6 +19861,7 @@ Transform:
   - {fileID: 326870768}
   - {fileID: 162775318}
   - {fileID: 835656000}
+  - {fileID: 525958789}
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -41484,7 +41527,6 @@ MonoBehaviour:
   fishTreatPrefab: {fileID: 246226352112295802, guid: d48770eaeb2450041975b4b13379f0bd, type: 3}
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
-  fishtreats: []
   laneNumber: 1
   spacingSize: 2
 --- !u!4 &1563533518
@@ -43086,7 +43128,6 @@ MonoBehaviour:
   fishTreatPrefab: {fileID: 246226352112295802, guid: d48770eaeb2450041975b4b13379f0bd, type: 3}
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
-  fishtreats: []
   laneNumber: 3
   spacingSize: 2
 --- !u!4 &1626550414
@@ -55101,7 +55142,6 @@ MonoBehaviour:
   fishTreatPrefab: {fileID: 246226352112295802, guid: d48770eaeb2450041975b4b13379f0bd, type: 3}
   checkpointPrefab: {fileID: 8860076903930998181, guid: 6bf176ba7eb508d4e9ab545eadcb1a2f, type: 3}
   platforms: []
-  fishtreats: []
   laneNumber: 0
   spacingSize: 2
 --- !u!4 &2122082842

--- a/Assets/Scripts/ManagerScripts/FishTreatManager.cs
+++ b/Assets/Scripts/ManagerScripts/FishTreatManager.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using UnityEngine;
+
+public sealed class FishTreatManager : MonoBehaviour
+{
+        public static FishTreatManager Current;
+        public event Action FishUnhideEvent;
+        private void Awake()
+        {
+                Current = this;
+        }
+
+
+        public void OnFishUnhideEvent()
+        {
+                FishUnhideEvent?.Invoke();
+        }
+}

--- a/Assets/Scripts/ManagerScripts/FishTreatManager.cs.meta
+++ b/Assets/Scripts/ManagerScripts/FishTreatManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 03606caf957a41b5af08bae2fe47e30f
+timeCreated: 1670215005

--- a/Assets/Scripts/ManagerScripts/Lane.cs
+++ b/Assets/Scripts/ManagerScripts/Lane.cs
@@ -10,7 +10,6 @@ public class Lane : MonoBehaviour
     public GameObject fishTreatPrefab;
     public GameObject checkpointPrefab;
     public List<Platform> platforms = new List<Platform>();
-    public List<FishHit> fishtreats = new List<FishHit>();
     
     public int laneNumber;
     private float _oneEighthofBeat;
@@ -93,34 +92,5 @@ public class Lane : MonoBehaviour
         // Debug.Log(spawn_time);
         newFishtreat.transform.localPosition = position;
         newFishtreat.transform.rotation = transform.rotation;
-        fishtreats.Add(newFishtreat.GetComponent<FishHit>());
-    }
-
-    public void RespawnAllFishTreats(IEnumerable<Note> array)
-    {
-        _oneEighthofBeat = 1 / (MusicPlayer.Current.bpm / 60f) / 2;
-        foreach (var note in array)
-        {
-            var metricTimeSpan =
-                TimeConverter.ConvertTo<MetricTimeSpan>(note.Time, MusicPlayer.MidiFileTest.GetTempoMap());
-            var spawnTime = ((double)metricTimeSpan.Minutes * 60f + metricTimeSpan.Seconds +
-                             (double)metricTimeSpan.Milliseconds / 1000f);
-            if (note.NoteName == fishTreatNote)
-            {
-                SpawnFishTreat(note.Octave, note.Velocity, (float)spawnTime, _oneEighthofBeat);
-            }
-        }
-    }
-
-    public void DestroyAllFishTreats()
-    {
-        foreach (var fishHit in fishtreats)
-        {
-            // Check it is not NULL
-            if (fishHit)
-            {
-                fishHit.DestroyFishTreat();
-            }
-        }
     }
 }

--- a/Assets/Scripts/ManagerScripts/MusicPlayer.cs
+++ b/Assets/Scripts/ManagerScripts/MusicPlayer.cs
@@ -97,13 +97,6 @@ public class MusicPlayer : MonoBehaviour
 
     public void ResetAllFishTreats()
     {
-        var notes = MidiFileTest.GetNotes();
-        var array = new Note[notes.Count];
-        // Debug.Log(notes.Count);
-        notes.CopyTo(array, 0);
-        foreach (var lane in lanes){
-            lane.DestroyAllFishTreats();
-            lane.RespawnAllFishTreats(array);
-        }
+        FishTreatManager.Current.OnFishUnhideEvent();
     }
 }

--- a/Assets/Scripts/ObjectScripts/FishHit.cs
+++ b/Assets/Scripts/ObjectScripts/FishHit.cs
@@ -2,21 +2,29 @@ using UnityEngine;
 
 public class FishHit : MonoBehaviour
 {
+    private Vector3 _initLocalScale;
+    private void Start()
+    {
+        _initLocalScale = transform.localScale;
+        FishTreatManager.Current.FishUnhideEvent += UnhideFishTreat;
+    }
+
     private void OnTriggerEnter(Collider otherCollider) 
     {
         if (otherCollider.gameObject.CompareTag("Player"))
         {
-            DestroyFishTreat();
+            HideFishTreat();
             ScoreManager.current.UpdateFishScore(1);
         }
     }
 
-    public void DestroyFishTreat()
+    private void HideFishTreat()
     {
-        // Check it is not NULL
-        if (gameObject)
-        {
-            Destroy(gameObject);
-        }
+        transform.localScale = new Vector3(0, 0, 0);
+    }
+
+    private void UnhideFishTreat()
+    {
+        transform.localScale = _initLocalScale;
     }
 }


### PR DESCRIPTION
- Hides fishtreats when the player gets them
- Unhides all fishtreats using an event
- Note: This should be faster than the previous implementation. The previous implementation lead to a long freeze when the player dies