### PR TITLE
Tweak movement and sync offset settings for level 2

### DIFF
--- a/Assets/Scenes/LevelTwoScene.unity
+++ b/Assets/Scenes/LevelTwoScene.unity
@@ -3171,6 +3171,21 @@ MonoBehaviour:
   lostLevelUI: {fileID: 386729660}
   gameUI: {fileID: 56649943}
   loadingScreen: {fileID: 2109638826}
+  PS4Tutorial:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  XboxTutorial:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  KeyboardTutorial:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
 --- !u!4 &132173032 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7573723302174861771, guid: 3c9bbaa3fd30c49088734acf5995b9c7, type: 3}

--- a/Assets/Scenes/LevelTwoScene.unity
+++ b/Assets/Scenes/LevelTwoScene.unity
@@ -6918,6 +6918,10 @@ PrefabInstance:
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
+      propertyPath: niceMarginOfError
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
       propertyPath: lanes.Array.data[0]
       value: 
       objectReference: {fileID: 11918407}
@@ -6945,6 +6949,10 @@ PrefabInstance:
       propertyPath: lanes.Array.data[6]
       value: 
       objectReference: {fileID: 32384471}
+    - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
+      propertyPath: perfectMarginOfError
+      value: 0.2
+      objectReference: {fileID: 0}
     - target: {fileID: 1067746485611210755, guid: c24b3dd7804a34438a5409311918549c, type: 3}
       propertyPath: playerActions.Array.size
       value: 2
@@ -29301,10 +29309,9 @@ MonoBehaviour:
   jumpSound4: {fileID: 9180474}
   landFromJumpSound: {fileID: 266175418}
   walkingSound: {fileID: 1370060877}
-  sidewayWalkSpeed: 13.05
-  forwardWalkSpeed: 10.7
+  sidewayWalkSpeed: 12.79
+  forwardWalkSpeed: 10.79
   lanePositions: []
-  centerLane: 3
   currentLane: 0
   numberOfLanes: 7
   groundDrag: 4
@@ -29330,7 +29337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cdb69c433ca0484a9e2a538a25cabb7b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  offset: 1.05
+  offset: 1.13468
   teleportSound: {fileID: 502785736}
 --- !u!114 &1828724623 stripped
 MonoBehaviour:


### PR DESCRIPTION
Used math and the timings of the notes plus the player's positions on those notes to calculate exactly what the forward movement speed should be. From there I trial-and-errored numbers for the forward speed (because in Unity we have some friction so the player movement speed isn't actually what it is in the game). I assumed sidemovement speed is forward movement + 2 (based on the other scenes), and calculated what the offset should be based on the forward movement speed (It's actual forward movement speed - desired forward movement speed). We can probably do these steps for the tutorial scene to calculate exactly what the speeds and offset should be.

I also tested different margins of error and 0.2 for perfect and 0.7 for nice makes this level not a complete messs